### PR TITLE
Sprint 3 - Finalización:  Empaquetado y Pruebas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 # Makefile - Sprint 2
-export DNS_SERVER ?= 8.8.8.8
-export DOMAINS=uni.edu.pe,youtube.com
+
 OUT_DIR             := out
 RAW_DIR         	:= $(OUT_DIR)/raw
 CSV_DIR         	:= $(OUT_DIR)/csv
@@ -58,9 +57,9 @@ snapshot: tools
 	mkdir -p $$snapshot_dir/csv $$snapshot_dir/raw; \
 	echo "consultar dominios"; \
 	DOMAINS=$(DOMAINS) DNS_SERVER=$(DNS_SERVER); \
-	src/consulta.sh $$snapshot_dir; \
+	src/consulta_snapshot.sh $$snapshot_dir; \
 	echo "generar archivo csv"; \
-	src/actualizador-csv.sh $$snapshot_dir; \
+	src/actualizador-csv-snapshot.sh $$snapshot_dir; \
 	echo "validar csv"; \
 	src/validar-csv.sh $$snapshot_dir/csv/resolucion.csv; \
 	echo "snapshot completado"
@@ -87,10 +86,12 @@ test: ## Ejecuta la pruebas bats de forma reproducible
 clean: ## Elimina los archivos y directorios generados
 	@echo "Limpiando archivos generados..."
 	@rm -rf $(OUT_DIR) $(DIST_DIR)
+	@rm -rf dist/
 
 pack: clean
 
 	@echo "empaquetando el proyecto"
+	@mkdir -p dist/
 	@tar -czvf dist/auditor-dns-v1.0.0.tar.gz src/ docs/ tests/ Makefile
 
 red: ## asegurar que falle el test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Makefile - Sprint 2
-
+export DNS_SERVER ?= 8.8.8.8
+export DOMAINS=uni.edu.pe,youtube.com
 OUT_DIR             := out
 RAW_DIR         	:= $(OUT_DIR)/raw
 CSV_DIR         	:= $(OUT_DIR)/csv
@@ -8,8 +9,7 @@ BATS_EXEC           := ./tests/bats/bin/bats
 TOOLS               := dig awk grep sort
 
 CONSULTA_FLAG   := $(RAW_DIR)/.consulta
-
-
+COMPARAR_SCRIPT := src/comparar-historicos.sh
 
 # Evita conflictos con nombres de archivos
 .PHONY: help tools build run test clean rgr red green refactor
@@ -47,6 +47,38 @@ $(CONSULTA_FLAG): src/consulta.sh
 	@touch $(CONSULTA_FLAG)
 
 
+validar: $(FINAL_CSV)
+	@echo "valida cabecera del csv"
+	@bash src/validar-csv.sh $(FINAL_CSV)
+
+snapshot: tools
+	@timestamp=$$(src/sello-tiempo.sh); \
+	echo "se creo un snapshot en timestamp"; \
+	snapshot_dir=$(OUT_DIR)/$$timestamp; \
+	mkdir -p $$snapshot_dir/csv $$snapshot_dir/raw; \
+	echo "consultar dominios"; \
+	DOMAINS=$(DOMAINS) DNS_SERVER=$(DNS_SERVER); \
+	src/consulta.sh $$snapshot_dir; \
+	echo "generar archivo csv"; \
+	src/actualizador-csv.sh $$snapshot_dir; \
+	echo "validar csv"; \
+	src/validar-csv.sh $$snapshot_dir/csv/resolucion.csv; \
+	echo "snapshot completado"
+
+compare:
+	@echo "comparar los snapshots"
+	@if [ $$(ls -1q $(OUT_DIR) | wc -l) -lt 2 ]; then \
+		echo "se necesita por lo menos 2 snapshot"; \
+	fi
+
+	@latest=$$(ls -1 $(OUT_DIR) | tail -n 1); \
+	previous=$$(ls -1 $(OUT_DIR) | tail -n 2 | head -n 1); \
+	echo "Anterior: $$previous"; \
+	echo "actual: $$latest"; \
+	src/comparar-historicos.sh $(OUT_DIR)/$$previous/csv $(OUT_DIR)/$$latest/csv
+
+
+
 test: ## Ejecuta la pruebas bats de forma reproducible
 	@echo " Ejecutando pruebas..."
 	@$(BATS_EXEC) tests/*.bats
@@ -55,6 +87,11 @@ test: ## Ejecuta la pruebas bats de forma reproducible
 clean: ## Elimina los archivos y directorios generados
 	@echo "Limpiando archivos generados..."
 	@rm -rf $(OUT_DIR) $(DIST_DIR)
+
+pack: clean
+
+	@echo "empaquetando el proyecto"
+	@tar -czvf dist/auditor-dns-v1.0.0.tar.gz src/ docs/ tests/ Makefile
 
 red: ## asegurar que falle el test
 	@if $(BATS_EXEC) tests/*.bats; then\

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,14 @@ find tests/bats -type f -exec dos2unix {} +
 ```bash
     DOMAINS="google.com,uni.edu.pe" DNS_SERVER=1.1.1.1 make refactor
 ```
+5. **Generar archivos csv en un determinado tiempo**
+```bash
+    DOMAINS="google.com,uni.edu.pe" DNS_SERVER=1.1.1.1 make snapshot
+```
+4. **Comparar csv originados a traves de make snapshot**
+```bash
+    make Compare
+```
 ## Configuración (Variables de Entorno)
 
 La configuración se gestiona exclusivamente a través de variables de entorno, siguiendo el principio III de 12-Factor.
@@ -89,7 +97,4 @@ La configuración se gestiona exclusivamente a través de variables de entorno, 
 |----------------|------------------------------------------------------------|-------------------|
 | `DNS_SERVER`   | Servidor DNS a utilizar para las consultas (`dig,grep,awk,sort`).   | (System default)  |
 | `DOMAINS` | Ruta al archivo con la lista de dominios a auditar.        |Lista de dominios separadas por comas     |
-
-
-### Ejemplos de Ejecución
 

--- a/docs/bitacora-sprint-1.md
+++ b/docs/bitacora-sprint-1.md
@@ -9,9 +9,35 @@
 
 ## Comandos ejecutados (muestra)
 - bats tests/sello-tiempo.bats
+```bash
+sello-tiempo.bats
+ ✓ imprime timestamp UTC con formato correcto
+ ✓ no tiene espacios ni caracteres raros
+```
 - bats tests/comparador_base.bats
+```bash
+comparador_base.bats
+ ✓ muestra uso cuando faltan argumentos
+ ✓ falla si no existen los resolucion.csv
+ ```
 - bats tests/validar_csv_base.bats
-
+```bash
+validar_csv_base.bats
+ ✓ exige argumento
+ ✓ falla si no existe archivo
+```
 ## Pendientes (bloqueados hasta que Sergio genere CSV)
 - Lógica de diffs (altas/bajas/ttl-anómalo) e informe.csv
 - Pruebas Bats con datos reales
+```bash
+henry@LAPTOP-J58LHNLD:/mnt/d/DESARROLLO-SOFTWARE/PC2-CC3S2$ make compare
+comparar los snapshots
+Anterior: 2025-10-01T01-53-50Z
+actual: 2025-10-01T01-54-00Z
+OK: diffs generados en out/2025-10-01T01-54-00Z/csv/diff
+Archivos:
+altas.csv
+bajas.csv
+informe.csv
+ttl-anomalo.csv
+```

--- a/docs/bitacora-sprint3.md
+++ b/docs/bitacora-sprint3.md
@@ -1,0 +1,93 @@
+# Bitácora – Sprint 3
+
+## Objetivos de este sprint
+-Integrar los scripts de comparacion de historicos en el makefile \
+-Implementar un empaquetador reproducible make pack para la entrega final del proyecto
+
+## Desarrollo de snapshot
+
+-Para realizar la comparacion de los historicos se implemento en makefile snapshot que va a permitir guardar el historial en diferentes cortes de tiempo
+
+```bash
+henry@LAPTOP-J58LHNLD:/mnt/d/DESARROLLO-SOFTWARE/PC2-CC3S2$ DNS_SERVER="8.8.8.8" DOMAINS="google.com,github.com" make snapshot
+Verificando dependencias...
+Todas las dependencias están instaladas.
+se creo un snapshot en timestamp
+consultar dominios
+generar archivo csv
+validar csv
+OK: cabecera válida en out/2025-10-01T01-53-50Z/csv/resolucion.csv
+snapshot completado
+henry@LAPTOP-J58LHNLD:/mnt/d/DESARROLLO-SOFTWARE/PC2-CC3S2$ DNS_SERVER="8.8.8.8" DOMAINS="google.com,github.com" make snapshot
+Verificando dependencias...
+Todas las dependencias están instaladas.
+se creo un snapshot en timestamp
+consultar dominios
+generar archivo csv
+validar csv
+OK: cabecera válida en out/2025-10-01T01-54-00Z/csv/resolucion.csv
+snapshot completado
+```
+-Para dicha comparacion se hace uso de make compare que va a tomar los dos ultimos snapshots y compararlos
+
+```bash
+henry@LAPTOP-J58LHNLD:/mnt/d/DESARROLLO-SOFTWARE/PC2-CC3S2$ make compare
+comparar los snapshots
+Anterior: 2025-10-01T01-53-50Z
+actual: 2025-10-01T01-54-00Z
+OK: diffs generados en out/2025-10-01T01-54-00Z/csv/diff
+Archivos:
+altas.csv
+bajas.csv
+informe.csv
+ttl-anomalo.csv
+```
+## Empaquetado de carpetas
+-Se empaqueto las carpetas necesarias para sacar adelante el proyecto
+```bash
+henry@LAPTOP-J58LHNLD:/mnt/d/DESARROLLO-SOFTWARE/PC2-CC3S2$ make pack
+Limpiando archivos generados...
+empaquetando el proyecto
+src/
+src/.gitkeep
+src/actualizador-csv-snapshot.sh
+src/actualizador-csv.sh
+src/comparar-historicos.sh
+src/consulta.sh
+src/consulta_snapshot.sh
+src/sello-tiempo.sh
+src/validar-csv.sh
+docs/
+docs/.gitkeep
+docs/bitacora-sprint-1.md
+docs/bitacora-sprint3.md
+docs/bitacora_sprint1.md
+docs/bitacora_sprint2.md
+docs/contrato-salidas.md
+docs/README.md
+tests/
+tests/.gitkeep
+tests/bats/
+tests/bats/.codespellrc
+tests/bats/.devcontainer/
+tests/bats/.devcontainer/devcontainer.json
+tests/bats/.devcontainer/Dockerfile
+tests/bats/.editorconfig
+tests/bats/.git
+tests/bats/.gitattributes
+tests/bats/.github/
+tests/bats/.github/dependabot.yml
+tests/bats/.github/ISSUE_TEMPLATE/
+tests/bats/.github/ISSUE_TEMPLATE/bug_report.md
+tests/bats/.github/ISSUE_TEMPLATE/feature_request.md
+tests/bats/.github/workflows/
+tests/bats/.github/workflows/check_pr_label.sh
+tests/bats/.github/workflows/codespell.yml
+tests/bats/.github/workflows/dependency-review.yml
+```
+- se realizo el test para verificar que se creo el directorio tar
+```bash
+pack.bats
+ ✓ make pack: generar el tar en la carpeta dist
+ ✓ make pack:debe contener los archivos correctos
+```

--- a/docs/bitacora_sprint1.md
+++ b/docs/bitacora_sprint1.md
@@ -1,6 +1,6 @@
 # Bitácora – Sprint 1
 
-## 📌 Objetivos de este sprint
+##  Objetivos de este sprint
 
 - Implementar Makefile mínimo con targets básicos (`tools`, `build`, `run`, `test`, `clean`).
 - Escribir primera prueba Bats con metodología AAA/RGR.
@@ -8,7 +8,7 @@
 
 ---
 
-## 📌 Comandos ejecutados
+##  Comandos ejecutados
 
 ### 1. Verificación de dependencias
 

--- a/src/actualizador-csv-snapshot.sh
+++ b/src/actualizador-csv-snapshot.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+trap error ERR
+
+error(){
+    echo "Ha ocurrido un error en src/actualizador-csv-snapshot.sh"
+    exit 1
+}
+
+if [[ $# -eq 1 ]]; then
+    DIRECTORIO_SALIDA="$1/csv"
+    DIRECTORIO_RAW="$1/raw"
+else
+    DIRECTORIO_RAIZ="$(dirname "$(dirname "$(realpath "$0")")")"
+    DIRECTORIO_SALIDA="${DIRECTORIO_RAIZ}/out/csv"
+    DIRECTORIO_RAW="${DIRECTORIO_RAIZ}/out/raw"
+fi
+
+mkdir -p "$DIRECTORIO_SALIDA"
+
+CSV_FILE="${DIRECTORIO_SALIDA}/resolucion.csv"
+
+
+if [[ ! -f "$CSV_FILE" ]]; then
+    echo "dominio,tipo,valor,ttl,fecha" > "$CSV_FILE"
+fi
+
+
+shopt -s nullglob
+raw_files=("${DIRECTORIO_RAW}"/salida_dig*.txt)
+
+if [[ ${#raw_files[@]} -eq 0 ]]; then
+    echo "ERROR: no se encontraron archivos en ${DIRECTORIO_RAW}" >&2
+    exit 2
+fi
+
+
+for raw in "${raw_files[@]}"; do
+    ts=$(tail -n 1 "$raw") # Extrae timestamp
+    awk '/ANSWER SECTION/,/^$/' "$raw" \
+        | tail -n +2 \
+        | awk -v OFS=, -v ts="$ts" 'NF{print $1,$4,$5,$2,ts}' \
+        >> "$CSV_FILE"
+done

--- a/src/consulta_snapshot.sh
+++ b/src/consulta_snapshot.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+[[ $# -eq 1 ]] || { echo "Uso: $0 <directorio_snapshot>" >&2; exit 1; }
+DIRECTORIO_SALIDA="$1/raw"
+mkdir -p "${DIRECTORIO_SALIDA}"
+
+trap 'echo "Ha ocurrido un error"' ERR
+
+# Guardar los dominios objetivo en un arreglo
+IFS=',' read -r -a DOMAINS_ARR <<< "$DOMAINS"
+i=0
+for d in "${DOMAINS_ARR[@]}"; do
+    # Guardar la salida de la consulta a cada dominio en archivos
+    ts=$(date -u +%FT%TZ) # Timestamp
+    NS_SERVER=$(dig @"$DNS_SERVER" "$d" NS +short | head -n1 | sed 's/\.$//') # Servidor autoritativo
+    dig "@${NS_SERVER}" "${d}" +norecurse > "${DIRECTORIO_SALIDA}/salida_dig$i.txt" # Consulta a servidor autoritativo
+    echo $ts >> "${DIRECTORIO_SALIDA}/salida_dig$i.txt"
+    ((i+=1))
+done
+

--- a/tests/pack.bats
+++ b/tests/pack.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+PACKAGE_NAME="dist/auditor-dns-v1.0.0.tar.gz"
+setup(){
+    make clean > /dev/null
+}
+
+@test "make pack: generar el tar en la carpeta dist" {
+    [ ! -f "$PACKAGE_NAME" ]
+
+    run make pack
+
+    [ "$status" -eq 0 ]
+    [ -f "$PACKAGE_NAME" ]
+}
+
+@test "make pack:debe contener los archivos correctos" {
+
+    run make pack
+    [ "$status" -eq 0 ]
+
+    echo "$output" | grep -q "src/"
+    echo "$output" | grep -q "docs/"
+    echo "$output" | grep -q "tests/"
+    echo "$output" | grep -q "Makefile"
+}


### PR DESCRIPTION
**¿Qué se hizo?**

-se diseñó el Makefile para gestionar "snapshots"  de las auditorías de DNS.
-Se implementó un target make pack que genera un paquete .tar.gz limpio y distribuible del proyecto.
-Pruebas de Calidad para el Paquete: Se añadió una nueva suite de pruebas (tests/pack.bats) para validar automáticamente el contenido del paquete generado.

**¿Por qué se hizo?**

-El Makefile anterior no podía cumplir con el requisito principal del proyecto: comparar históricos. Era necesario un sistema que pudiera gestionar múltiples resultados a lo largo del tiempo sin intervención manual.

-Para la entrega final, se requiere un artefacto limpio y reproducible que contenga únicamente el código fuente, la documentación y las pruebas.
**¿Cómo se hizo?**
Se implementaron dos nuevos targets principales en el Makefile:
- make snapshot: Este comando ahora es el punto de entrada para realizar una auditoría. Utiliza el script sello-tiempo.sh para crear un directorio único (ej. out/2025-09-30T22-10-00Z/) y luego orquesta la ejecución de consulta.sh, actualizador-csv.sh y validar-csv.sh dentro de ese directorio. Esto asegura que cada auditoría se guarde como un "corte" histórico sin sobrescribir los resultados anteriores.
-make compare:  Busca  los dos subdirectorios más recientes en out/, los extrae, y se los pasa como argumentos al script comparar-historicos.sh. 
-make pack: Busca generar un paquete el cual contenga todos los archivos necesarios para poder desarrollar el proyecto

**Evidencia**
henry@LAPTOP-J58LHNLD:/mnt/d/DESARROLLO-SOFTWARE/PC2-CC3S2$ DNS_SERVER="8.8.8.8" DOMAINS="google.com,github.com" make snapshot
Verificando dependencias...
Todas las dependencias están instaladas.
se creo un snapshot en timestamp
consultar dominios
generar archivo csv
validar csv
OK: cabecera válida en out/2025-10-01T01-54-00Z/csv/resolucion.csv
snapshot completado

henry@LAPTOP-J58LHNLD:/mnt/d/DESARROLLO-SOFTWARE/PC2-CC3S2$ make compare
comparar los snapshots
Anterior: 2025-10-01T01-53-50Z
actual: 2025-10-01T01-54-00Z
OK: diffs generados en out/2025-10-01T01-54-00Z/csv/diff
Archivos:
altas.csv
bajas.csv
informe.csv
ttl-anomalo.csv